### PR TITLE
Update index.markdown with corrected links

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -25,13 +25,14 @@ are open-source and free to use.
 
 The VIPs will be developed with UVM following the best industry practices. 
 They will come with comprehensive documentation and user guides. You can 
-check the available VIPs on the [Projects](Projects) page.
+check the available VIPs on the [Projects](/projects) page.
 
-The code in this repository is released under the permissive [MIT License](license). 
+The code in this repository is released under the permissive [MIT License](/license). 
 Feel free to use it in your projects. 
 You can write to [mbits@mirafra.com](mailto:mbits@mirafra.com) if you 
 need help in using the VIPs in your verification environments.
 
 We welcome contributions from the community. If you would like to contribute, 
-check out the [Guidelines](Guidelines) page.
+check out the [Guidelines](/contribute) page.
+
 


### PR DESCRIPTION
Changed two links (projects and guidelines) in the homepage which were leading to non-existent pages (Projects and Guidelines - Case sensitivity issue) causing a redirect to 404 page. This commit fixes those links (to /projects and /contribute) to redirect the user to the intended pages.